### PR TITLE
feat: control okna (parametrické GUI ovládané z backendu) + křivkové hrany

### DIFF
--- a/examples/showcase.py
+++ b/examples/showcase.py
@@ -53,5 +53,20 @@ def provoz():
         canvas.update_node(cl, color="#05ffa1", status="idle")
 
 
+# control okno: přepínání stylu hran (čára/splajn) + elasticita
+_render_win = vb.ControlWindow("render", title="Vykreslování")
+_render_win.enum("style", "Hrany",
+                 options=[("line", "Čáry"), ("spline", "Splajny")],
+                 value="line")
+_render_win.integer("elasticity", "Elasticita", min=0, max=100, value=30)
+
+
+def _apply_render(event):
+    canvas.set_edge_style(event.values["style"],
+                          elasticity=event.values["elasticity"] / 100)
+
+
+canvas.open_window(_render_win, on_submit=_apply_render)
+
 threading.Thread(target=provoz, daemon=True).start()
 vb.serve(canvas, port=8080, open_browser=True)

--- a/frontend/src/core/store.js
+++ b/frontend/src/core/store.js
@@ -5,6 +5,7 @@ export class GraphStore {
     this.nodeTypes = {};
     this.flowTypes = {};
     this.flows = [];
+    this.windows = [];
     this.nodes = new Map();   // id -> {id, type, label, meta}
     this.edges = new Map();   // edgeKey -> {source, target, meta}
     this.seq = -1;
@@ -31,6 +32,7 @@ export class GraphStore {
     this.nodeTypes = msg.node_types;
     this.flowTypes = msg.flow_types ?? {};
     this.flows = msg.flows ?? [];
+    this.windows = msg.windows ?? [];
     this.nodes.clear();
     this.edges.clear();
     for (const node of msg.nodes) this.nodes.set(node.id, node);

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -86,11 +86,11 @@ function bootstrap() {
   store.subscribe((event) => {
     if (event.kind !== 'init') return;
     renderer.flowController.replayInit(store.flows ?? []);
+    applyTheme(store.config.theme);   // téma (i CSS proměnné oken) nastav dřív
     renderer.setEdgeStyle(store.config.edge_style ?? { style: 'line', elasticity: 0 });
     for (const spec of store.windows ?? []) {
       windowManager.openControl(spec, submitWindow);
     }
-    applyTheme(store.config.theme);
     if (store.config.title) {
       document.title = `${store.config.title} – viewbase`;
     }

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -86,6 +86,10 @@ function bootstrap() {
   store.subscribe((event) => {
     if (event.kind !== 'init') return;
     renderer.flowController.replayInit(store.flows ?? []);
+    renderer.setEdgeStyle(store.config.edge_style ?? { style: 'line', elasticity: 0 });
+    for (const spec of store.windows ?? []) {
+      windowManager.openControl(spec, submitWindow);
+    }
     applyTheme(store.config.theme);
     if (store.config.title) {
       document.title = `${store.config.title} – viewbase`;
@@ -100,6 +104,10 @@ function bootstrap() {
     // 'high': žádný watchdog, nikdy nedegradovat
   });
 
+  function submitWindow(payload) {
+    connection.send(buildEvent('window_submit', payload));
+  }
+
   const actions = {
     show_detail: (msg) => windowManager.openFor(msg.node_id),
     focus: (msg) => renderer.focusOn(msg.node_id),
@@ -110,6 +118,9 @@ function bootstrap() {
       store.config.theme = msg.theme;     // reconnect → init už ponese nové téma
       applyTheme(msg.theme);
     },
+    open_window: (msg) => windowManager.openControl(msg, submitWindow),
+    close_window: (msg) => windowManager.closeControl(msg.window_id),
+    set_edge_style: (msg) => renderer.setEdgeStyle(msg),
   };
 
   const wsScheme = location.protocol === 'https:' ? 'wss' : 'ws';

--- a/frontend/src/render/base_window.js
+++ b/frontend/src/render/base_window.js
@@ -1,0 +1,219 @@
+/** Sdílené chrome okno (Amiga Workbench): záhlaví s gadgety zavřít/
+ *  minimalizovat/obnovit, tažení za záhlaví, dok vlevo dole, z-order.
+ *  Tělo dodává podtřída: nastaví this.body v _buildBody() a (volitelně)
+ *  překresluje v _renderBody(). Podtřída v konstruktoru po super() nastaví
+ *  svá pole, pak zavolá this._buildBody() a this._mount(). Čisté funkce
+ *  clampToCanvas/dockLayout jsou tu; windows.js je re-exportuje. */
+
+export function clampToCanvas(x, y, w, h, bounds) {
+  const maxX = Math.max(0, bounds.width - w);
+  const maxY = Math.max(0, bounds.height - h);
+  return {
+    x: Math.min(Math.max(0, x), maxX),
+    y: Math.min(Math.max(0, y), maxY),
+  };
+}
+
+export function dockLayout(index, slotWidth, gap, canvasHeight, slotHeight) {
+  return { x: index * (slotWidth + gap), y: canvasHeight - slotHeight };
+}
+
+const DOCK_SLOT_WIDTH = 160;
+const DOCK_GAP = 8;
+const DOCK_SLOT_HEIGHT = 28;
+
+export class BaseWindow {
+  constructor({ id, title, widthChars, container, manager, kind }) {
+    this.id = id;
+    this.title = title;
+    this.widthChars = widthChars;
+    this.container = container;
+    this.manager = manager;
+    this.kind = kind;            // 'detail' | 'control'
+    this.isMinimized = false;
+    this.saved = null;
+    this.dragOffset = null;
+    this.body = null;            // nastaví _buildBody podtřídy
+
+    this.el = document.createElement('div');
+    this.el.dataset.role = 'vb-window';
+    this.el.dataset.windowId = String(id);
+    this.el.style.cssText = [
+      'position:absolute', 'left:0', 'top:0', 'box-sizing:border-box',
+      'background:var(--vb-window-body-bg, rgba(255,255,255,0.97))',
+      'color:var(--vb-window-body-fg, #1f2430)',
+      'box-shadow:var(--vb-window-shadow, 0 6px 20px rgba(0,0,0,0.22))',
+      'border-radius:6px', 'overflow:hidden', 'user-select:none',
+      'font:13px/1.5 system-ui,sans-serif', 'z-index:900',
+    ].join(';');
+    this._buildHeader();
+  }
+
+  // -- hooky podtřídy --
+  _buildBody() { /* podtřída: vytvoř this.body a připoj do this.el */ }
+  _renderBody() { /* podtřída: refresh při tématu / obnově */ }
+
+  // -- po nastavení polí podtřídy --
+  _mount() {
+    this.container.appendChild(this.el);
+    const bounds = this._bounds();
+    const offset = (this.manager.windows.size % 8) * 24;
+    const start = clampToCanvas(40 + offset, 40 + offset,
+      this._width(), 200, bounds);
+    this._place(start.x, start.y);
+    this.el.addEventListener('pointerdown', () => this.bringToFront());
+  }
+
+  _width() { return this.widthChars * 8 + 24; }
+
+  _bounds() {
+    return {
+      width: this.container.clientWidth || 800,
+      height: this.container.clientHeight || 600,
+    };
+  }
+
+  _buildHeader() {
+    const bar = document.createElement('div');
+    bar.dataset.role = 'vb-titlebar';
+    bar.style.cssText = [
+      'display:flex', 'align-items:center', 'gap:6px',
+      'padding:4px 6px', 'cursor:move',
+      'background:var(--vb-window-header-bg, #d8dde6)',
+      'color:var(--vb-window-header-fg, #1f2430)',
+    ].join(';');
+
+    this.closeGadget = this._gadget('close', '×');
+    this.closeGadget.addEventListener('click', (e) => {
+      e.stopPropagation();
+      this.close();
+    });
+
+    this.titleEl = document.createElement('div');
+    this.titleEl.textContent = this.title;
+    this.titleEl.style.cssText = [
+      'flex:1', 'text-align:center', 'font-weight:600',
+      'white-space:nowrap', 'overflow:hidden', 'text-overflow:ellipsis',
+    ].join(';');
+
+    this.minGadget = this._gadget('minimize', '–');
+    this.minGadget.addEventListener('click', (e) => {
+      e.stopPropagation();
+      this.minimize();
+    });
+
+    this.restoreGadget = this._gadget('restore', '▢');
+    this.restoreGadget.addEventListener('click', (e) => {
+      e.stopPropagation();
+      this.restore();
+    });
+    this.restoreGadget.style.display = 'none';
+
+    bar.append(this.closeGadget, this.titleEl,
+      this.minGadget, this.restoreGadget);
+    this._dragFromHeader(bar);
+    this.bar = bar;
+    this.el.appendChild(bar);
+  }
+
+  _gadget(name, glyph) {
+    const g = document.createElement('button');
+    g.dataset.gadget = name;
+    g.textContent = glyph;
+    g.style.cssText = [
+      'flex:0 0 auto', 'width:18px', 'height:18px', 'line-height:16px',
+      'padding:0', 'border:1px solid var(--vb-window-gadget, #8a93a3)',
+      'border-radius:3px', 'background:transparent', 'cursor:pointer',
+      'color:var(--vb-window-gadget, #5a6573)', 'font-size:13px',
+    ].join(';');
+    return g;
+  }
+
+  _dragFromHeader(bar) {
+    bar.addEventListener('pointerdown', (e) => {
+      if (e.target.dataset.gadget) return;
+      this.bringToFront();
+      const rect = this.el.getBoundingClientRect();
+      const cont = this.container.getBoundingClientRect();
+      this.dragOffset = {
+        x: e.clientX - rect.left, y: e.clientY - rect.top,
+        contLeft: cont.left, contTop: cont.top,
+      };
+      bar.setPointerCapture(e.pointerId);
+    });
+    bar.addEventListener('pointermove', (e) => {
+      if (!this.dragOffset || this.isMinimized) return;
+      const x = e.clientX - this.dragOffset.contLeft - this.dragOffset.x;
+      const y = e.clientY - this.dragOffset.contTop - this.dragOffset.y;
+      const pos = clampToCanvas(x, y, this._width(), this._headerH(),
+        this._bounds());
+      this._place(pos.x, pos.y);
+    });
+    const end = (e) => {
+      if (this.dragOffset) {
+        this.dragOffset = null;
+        try { bar.releasePointerCapture(e.pointerId); } catch { /* noop */ }
+      }
+    };
+    bar.addEventListener('pointerup', end);
+    bar.addEventListener('pointercancel', end);
+  }
+
+  _headerH() { return this.bar.offsetHeight || DOCK_SLOT_HEIGHT; }
+
+  _place(x, y) {
+    this.x = x;
+    this.y = y;
+    this.el.style.left = `${x}px`;
+    this.el.style.top = `${y}px`;
+  }
+
+  minimize() {
+    if (this.isMinimized) return;
+    this.isMinimized = true;
+    this.saved = { x: this.x, y: this.y };
+    this.body.style.display = 'none';
+    this.minGadget.style.display = 'none';
+    this.restoreGadget.style.display = '';
+    this.el.dataset.role = 'vb-dock-strip';
+    this.el.style.background = 'var(--vb-window-dock-bg, #c2c9d4)';
+    this.el.style.width = `${DOCK_SLOT_WIDTH}px`;
+    this.titleEl.style.fontSize = '11px';
+    const slot = this.manager._assignDockSlot(this);
+    const bounds = this._bounds();
+    const pos = dockLayout(slot, DOCK_SLOT_WIDTH, DOCK_GAP,
+      bounds.height, DOCK_SLOT_HEIGHT);
+    this._place(pos.x, pos.y);
+  }
+
+  restore() {
+    if (!this.isMinimized) return;
+    this.isMinimized = false;
+    this.manager._releaseDockSlot(this);
+    this.el.dataset.role = 'vb-window';
+    this.el.style.background = 'var(--vb-window-body-bg, rgba(255,255,255,0.97))';
+    this.el.style.width = '';
+    this.titleEl.style.fontSize = '';
+    this.body.style.display = '';
+    this.minGadget.style.display = '';
+    this.restoreGadget.style.display = 'none';
+    this._renderBody();
+    const pos = this.saved ?? { x: 40, y: 40 };
+    this._place(pos.x, pos.y);
+    this.bringToFront();
+  }
+
+  bringToFront() { this.setZ(this.manager._nextZ()); }
+
+  setZ(z) { this.el.style.zIndex = String(z); }
+
+  applyTheme() {
+    if (!this.isMinimized) this._renderBody();
+  }
+
+  close() {
+    if (this.isMinimized) this.manager._releaseDockSlot(this);
+    this.el.remove();
+    this.manager._forget(this.id);
+  }
+}

--- a/frontend/src/render/base_window.js
+++ b/frontend/src/render/base_window.js
@@ -50,6 +50,8 @@ export class BaseWindow {
   }
 
   // -- hooky podtřídy --
+  // Pozn.: konstruktor BaseWindow _buildBody NEVOLÁ – podtřída ho zavolá sama
+  // až po nastavení svých polí (jinak by četl pole před super()).
   _buildBody() { /* podtřída: vytvoř this.body a připoj do this.el */ }
   _renderBody() { /* podtřída: refresh při tématu / obnově */ }
 

--- a/frontend/src/render/control_window.js
+++ b/frontend/src/render/control_window.js
@@ -1,0 +1,130 @@
+/** Control okno: formulářové tělo (int slider+číslo, string text, enum select)
+ *  + tlačítko Použít, které pošle všechny hodnoty zpět. Chrome dědí z
+ *  BaseWindow. Čisté helpery clampValue/readValues zrcadlí backend validaci. */
+import { BaseWindow } from './base_window.js';
+
+/** Zvaliduj jednu hodnotu podle field descriptoru (zrcadlo backendu).
+ *  Při nepoužitelné hodnotě ponech field.value. */
+export function clampValue(field, raw) {
+  if (field.type === 'int') {
+    const n = Math.round(Number(raw));
+    if (!Number.isFinite(n)) return field.value;
+    return Math.max(field.min, Math.min(field.max, n));
+  }
+  if (field.type === 'string') {
+    return String(raw ?? '').slice(0, field.maxlength);
+  }
+  if (field.type === 'enum') {
+    return field.options.some((o) => o.value === raw) ? raw : field.value;
+  }
+  return field.value;
+}
+
+/** rawMap {key: hodnota z widgetu} → {key: clampValue(...)} jen pro známé klíče. */
+export function readValues(fields, rawMap) {
+  const out = {};
+  for (const field of fields) {
+    if (field.key in rawMap) out[field.key] = clampValue(field, rawMap[field.key]);
+  }
+  return out;
+}
+
+export class ControlWindow extends BaseWindow {
+  constructor({ id, title, fields, widthChars, onSubmit, container, manager }) {
+    super({ id, title, widthChars, container, manager, kind: 'control' });
+    this.fields = fields;
+    this.onSubmit = onSubmit;
+    this.inputs = new Map();        // key -> () => rawValue
+    this._buildBody();
+    this._mount();
+  }
+
+  _buildBody() {
+    const body = document.createElement('div');
+    body.dataset.role = 'control-body';
+    body.style.cssText = [
+      'padding:8px 10px', `width:${this.widthChars}ch`, 'max-width:90vw',
+      'font:13px/1.5 system-ui,sans-serif',
+    ].join(';');
+    this.body = body;
+
+    const table = document.createElement('table');
+    table.style.cssText = 'border-collapse:collapse;width:100%';
+    for (const field of this.fields) {
+      const tr = table.insertRow();
+      const keyCell = tr.insertCell();
+      keyCell.textContent = field.label;
+      keyCell.style.cssText = [
+        'padding:3px 10px 3px 0', 'white-space:nowrap',
+        'color:var(--vb-window-key, #667788)',
+      ].join(';');
+      const valCell = tr.insertCell();
+      valCell.style.cssText = 'padding:3px 0';
+      this.inputs.set(field.key, this._buildWidget(field, valCell));
+    }
+    body.appendChild(table);
+
+    const apply = document.createElement('button');
+    apply.dataset.role = 'control-apply';
+    apply.textContent = 'Použít';
+    apply.style.cssText = [
+      'margin-top:8px', 'padding:3px 12px', 'cursor:pointer',
+      'border:1px solid var(--vb-window-gadget, #8a93a3)', 'border-radius:4px',
+      'background:transparent', 'color:inherit',
+    ].join(';');
+    apply.addEventListener('click', (e) => {
+      e.stopPropagation();
+      this._submit();
+    });
+    body.appendChild(apply);
+    this.el.appendChild(body);
+  }
+
+  _buildWidget(field, cell) {
+    if (field.type === 'enum') {
+      const sel = document.createElement('select');
+      for (const opt of field.options) {
+        const o = document.createElement('option');
+        o.value = String(opt.value);
+        o.textContent = opt.label;
+        if (opt.value === field.value) o.selected = true;
+        sel.appendChild(o);
+      }
+      cell.appendChild(sel);
+      return () => sel.value;
+    }
+    if (field.type === 'int') {
+      const range = document.createElement('input');
+      range.type = 'range';
+      range.min = field.min; range.max = field.max;
+      range.step = field.step ?? 1; range.value = field.value;
+      const num = document.createElement('input');
+      num.type = 'number';
+      num.min = field.min; num.max = field.max;
+      num.step = field.step ?? 1; num.value = field.value;
+      num.style.cssText = 'width:5em;margin-left:6px';
+      range.addEventListener('input', () => { num.value = range.value; });
+      num.addEventListener('input', () => { range.value = num.value; });
+      cell.append(range, num);
+      return () => num.value;
+    }
+    // string
+    const text = document.createElement('input');
+    text.type = 'text';
+    text.maxLength = field.maxlength;
+    text.value = field.value;
+    cell.appendChild(text);
+    return () => text.value;
+  }
+
+  _submit() {
+    const rawMap = {};
+    for (const [key, get] of this.inputs) rawMap[key] = get();
+    const values = readValues(this.fields, rawMap);
+    if (this.onSubmit) this.onSubmit({ window_id: this.id, values });
+  }
+
+  _renderBody() {
+    // formulář persistuje v DOM; téma ani obnova nevyžadují rebuild
+  }
+}

--- a/frontend/src/render/control_window.js
+++ b/frontend/src/render/control_window.js
@@ -87,11 +87,14 @@ export class ControlWindow extends BaseWindow {
         const o = document.createElement('option');
         o.value = String(opt.value);
         o.textContent = opt.label;
-        if (opt.value === field.value) o.selected = true;
+        if (String(opt.value) === String(field.value)) o.selected = true;
         sel.appendChild(o);
       }
       cell.appendChild(sel);
-      return () => sel.value;
+      // getter vrací NATIVNÍ hodnotu option (sel.value je vždy string), aby
+      // clampValue (o.value === raw) matchnul i ne-string enum hodnoty.
+      return () => field.options.find(
+        (opt) => String(opt.value) === sel.value)?.value ?? field.value;
     }
     if (field.type === 'int') {
       const range = document.createElement('input');

--- a/frontend/src/render/edges.js
+++ b/frontend/src/render/edges.js
@@ -1,0 +1,50 @@
+/** Křivková hrana: body kvadratického bezieru a→b s prohnutím (elasticita).
+ *  Vrací segments+1 bodů {x,y,z}. elasticity 0 → kolineární (rovná čára, bezier
+ *  s řídicím bodem ve středu degeneruje na úsečku). Řídicí bod = střed +
+ *  kolmice·(elasticity·délka·MAX_BOW); kolmice v 3D = dir × osa Y (fallback
+ *  osa X při rovnoběžnosti). */
+export const EDGE_SEGMENTS = 12;
+export const EDGE_MAX_BOW = 0.5;
+
+export function bezierEdgePoints(a, b, elasticity, segments = EDGE_SEGMENTS) {
+  const mx = (a.x + b.x) / 2;
+  const my = (a.y + b.y) / 2;
+  const mz = (a.z + b.z) / 2;
+  let cx = mx;
+  let cy = my;
+  let cz = mz;
+  const dx = b.x - a.x;
+  const dy = b.y - a.y;
+  const dz = b.z - a.z;
+  const len = Math.hypot(dx, dy, dz);
+  if (elasticity > 0 && len > 0) {
+    const ux = dx / len;
+    const uy = dy / len;
+    const uz = dz / len;
+    let px = -uz;            // dir × (0,1,0) = (-uz, 0, ux)
+    let py = 0;
+    let pz = ux;
+    if (Math.hypot(px, py, pz) < 1e-6) {   // dir ‖ osa Y → fallback ref X
+      px = 0; py = uz; pz = -uy;           // dir × (1,0,0) = (0, uz, -uy)
+    }
+    const pl = Math.hypot(px, py, pz) || 1;
+    const offset = elasticity * len * EDGE_MAX_BOW;
+    cx = mx + (px / pl) * offset;
+    cy = my + (py / pl) * offset;
+    cz = mz + (pz / pl) * offset;
+  }
+  const points = [];
+  for (let i = 0; i <= segments; i += 1) {
+    const t = i / segments;
+    const it = 1 - t;
+    const w0 = it * it;
+    const w1 = 2 * it * t;
+    const w2 = t * t;
+    points.push({
+      x: w0 * a.x + w1 * cx + w2 * b.x,
+      y: w0 * a.y + w1 * cy + w2 * b.y,
+      z: w0 * a.z + w1 * cz + w2 * b.z,
+    });
+  }
+  return points;
+}

--- a/frontend/src/render/renderer.js
+++ b/frontend/src/render/renderer.js
@@ -65,7 +65,7 @@ export class Renderer {
     this.edgeLines = null;
     this.edgeStyle = 'line';        // 'line' | 'spline'
     this.edgeElasticity = 0;        // 0..1
-    this._ensureEdgeCapacity(4096);
+    this._ensureEdgeCapacity(8192);   // ve VRCHOLECH (počáteční strop)
 
     this.clock = new THREE.Clock();
     this._matrix = new THREE.Matrix4();
@@ -375,6 +375,8 @@ export class Renderer {
   _syncEdges() {
     const { edges } = this.store;
     const spline = this.edgeStyle === 'spline' && this.edgeElasticity > 0;
+    // pozn.: spline alokuje body per-frame; pro velmi velké grafy by šlo psát
+    // přímo do BufferAttribute (default je 'line', takže to teď neřešíme).
     const perEdge = spline ? EDGE_SEGMENTS * 2 : 2;   // vrcholů na hranu
     this._ensureEdgeCapacity(edges.size * perEdge);
     const attr = this.edgeLines.geometry.getAttribute('position');

--- a/frontend/src/render/renderer.js
+++ b/frontend/src/render/renderer.js
@@ -7,6 +7,7 @@ import { resolveTheme } from '../themes/manager.js';
 import { nodeStyle } from './style.js';
 import { LabelLayer } from './labels.js';
 import { FlowController, FlowLayer } from './flow.js';
+import { bezierEdgePoints, EDGE_SEGMENTS } from './edges.js';
 
 const SMOOTHING = 8;            // 1/s – rychlost dobíhání zobrazené pozice k fyzice
 const DIM_TOWARD_BG = 0.75;     // ztlumené uzly: 75 % cesty k barvě pozadí
@@ -62,6 +63,8 @@ export class Renderer {
 
     this.edgeCapacity = 0;
     this.edgeLines = null;
+    this.edgeStyle = 'line';        // 'line' | 'spline'
+    this.edgeElasticity = 0;        // 0..1
     this._ensureEdgeCapacity(4096);
 
     this.clock = new THREE.Clock();
@@ -112,6 +115,13 @@ export class Renderer {
     this.labels.applyTheme(theme);
     this.flows.applyTheme(theme);
     this._syncBloom();
+  }
+
+  /** Styl hran z akce/initu: 'line' nebo 'spline' + elasticita 0..1.
+   *  Bez rebuildu – přepočet je per-frame v _syncEdges. */
+  setEdgeStyle({ style, elasticity } = {}) {
+    this.edgeStyle = style === 'spline' ? 'spline' : 'line';
+    this.edgeElasticity = Math.max(0, Math.min(1, elasticity ?? 0));
   }
 
   /** Vytvoří/zruší EffectComposer podle theme.bloom (a quality degradace).
@@ -236,9 +246,9 @@ export class Renderer {
     return mesh;
   }
 
-  _ensureEdgeCapacity(count) {
-    if (count <= this.edgeCapacity) return;
-    const capacity = Math.max(4096, 2 ** Math.ceil(Math.log2(count)));
+  _ensureEdgeCapacity(vertexCount) {
+    if (vertexCount <= this.edgeCapacity) return;
+    const capacity = Math.max(8192, 2 ** Math.ceil(Math.log2(vertexCount)));
     if (this.edgeLines) {
       this.scene.remove(this.edgeLines);
       this.edgeLines.geometry.dispose();
@@ -246,7 +256,7 @@ export class Renderer {
     }
     const geometry = new THREE.BufferGeometry();
     geometry.setAttribute('position',
-      new THREE.BufferAttribute(new Float32Array(capacity * 6), 3));
+      new THREE.BufferAttribute(new Float32Array(capacity * 3), 3));
     geometry.setDrawRange(0, 0);
     this.edgeLines = new THREE.LineSegments(geometry,
       new THREE.LineBasicMaterial({
@@ -256,7 +266,7 @@ export class Renderer {
       }));
     this.edgeLines.frustumCulled = false;
     this.scene.add(this.edgeLines);
-    this.edgeCapacity = capacity;
+    this.edgeCapacity = capacity;   // ve VRCHOLECH
   }
 
   start() {
@@ -364,18 +374,27 @@ export class Renderer {
 
   _syncEdges() {
     const { edges } = this.store;
-    this._ensureEdgeCapacity(edges.size);
+    const spline = this.edgeStyle === 'spline' && this.edgeElasticity > 0;
+    const perEdge = spline ? EDGE_SEGMENTS * 2 : 2;   // vrcholů na hranu
+    this._ensureEdgeCapacity(edges.size * perEdge);
     const attr = this.edgeLines.geometry.getAttribute('position');
-    let i = 0;
+    let v = 0;                                        // index vrcholu
     for (const edge of edges.values()) {
       const a = this.display.get(edge.source);
       const b = this.display.get(edge.target);
       if (!a || !b) continue;
-      attr.setXYZ(i * 2, a.x, a.y, a.z);
-      attr.setXYZ(i * 2 + 1, b.x, b.y, b.z);
-      i += 1;
+      if (spline) {
+        const pts = bezierEdgePoints(a, b, this.edgeElasticity, EDGE_SEGMENTS);
+        for (let i = 0; i < pts.length - 1; i += 1) {
+          attr.setXYZ(v, pts[i].x, pts[i].y, pts[i].z); v += 1;
+          attr.setXYZ(v, pts[i + 1].x, pts[i + 1].y, pts[i + 1].z); v += 1;
+        }
+      } else {
+        attr.setXYZ(v, a.x, a.y, a.z); v += 1;
+        attr.setXYZ(v, b.x, b.y, b.z); v += 1;
+      }
     }
-    this.edgeLines.geometry.setDrawRange(0, i * 2);
+    this.edgeLines.geometry.setDrawRange(0, v);
     attr.needsUpdate = true;
   }
 

--- a/frontend/src/render/windows.js
+++ b/frontend/src/render/windows.js
@@ -39,7 +39,6 @@ export function windowsToRefresh(patch, openIds) {
 export class DetailWindow extends BaseWindow {
   constructor({ nodeId, title, rows, widthChars, container, manager }) {
     super({ id: nodeId, title, widthChars, container, manager, kind: 'detail' });
-    this.nodeId = nodeId;
     this.rows = rows;
     this._buildBody();
     this._mount();

--- a/frontend/src/render/windows.js
+++ b/frontend/src/render/windows.js
@@ -1,6 +1,13 @@
-/** Window manager ve stylu Amiga Workbench: tažitelná okna s řádky
- *  klíč/hodnota nad canvasem. Tento soubor obsahuje čisté funkce (testované
- *  vitestem) a DOM třídy DetailWindow + WindowManager (manuální/E2E ověření). */
+/** Detailní okno (řádky klíč/hodnota nad uzlem) a správce oken. Chrome je v
+ *  base_window.js; tady je tělo detailu + WindowManager (detail i control).
+ *  Čisté funkce buildRows/windowsToRefresh jsou tu, clampToCanvas/dockLayout
+ *  se re-exportují z base_window.js (zpětná kompatibilita testů). */
+import { BaseWindow, clampToCanvas, dockLayout } from './base_window.js';
+import { ControlWindow } from './control_window.js';
+
+export { clampToCanvas, dockLayout };
+
+const CONTROL_WIDTH_CHARS = 30;
 
 /** node + šablona řádků → pole {label, value}.
  *  rowsTemplate = pole dvojic [label, metaKey]; null = jeden řádek na meta. */
@@ -16,27 +23,8 @@ export function buildRows(node, rowsTemplate) {
   }));
 }
 
-/** Clampne pozici okna tak, aby zůstalo uvnitř [0, bounds].
- *  Titulek/záhlaví zůstane viditelné; minimum je vždy 0. */
-export function clampToCanvas(x, y, w, h, bounds) {
-  const maxX = Math.max(0, bounds.width - w);
-  const maxY = Math.max(0, bounds.height - h);
-  return {
-    x: Math.min(Math.max(0, x), maxX),
-    y: Math.min(Math.max(0, y), maxY),
-  };
-}
-
-/** Pozice minimalizovaného proužku v doku vlevo dole pro daný index. */
-export function dockLayout(index, slotWidth, gap, canvasHeight, slotHeight) {
-  return {
-    x: index * (slotWidth + gap),
-    y: canvasHeight - slotHeight,
-  };
-}
-
-/** Z patche a množiny otevřených oken urči, co překreslit a co zavřít.
- *  remove má přednost před update (uzel v obou → jen close). */
+/** Z patche a množiny otevřených (detailních) oken urči, co překreslit a co
+ *  zavřít. remove má přednost před update (uzel v obou → jen close). */
 export function windowsToRefresh(patch, openIds) {
   const open = openIds instanceof Set ? openIds : new Set(openIds);
   const close = (patch.remove_nodes ?? []).filter((id) => open.has(id));
@@ -47,134 +35,30 @@ export function windowsToRefresh(patch, openIds) {
   return { refresh, close };
 }
 
-const DOCK_SLOT_WIDTH = 160;
-const DOCK_GAP = 8;
-const DOCK_SLOT_HEIGHT = 28;
-
-/** Jedno okno: záhlaví (zavřít vlevo, titulek uprostřed, minimalizovat vpravo)
- *  + tělo s řádky klíč/hodnota. Minimalizace ho smrskne do proužku v doku. */
-export class DetailWindow {
+/** Detailní okno: tělo = tabulka řádků klíč/hodnota; klik na hodnotu kopíruje. */
+export class DetailWindow extends BaseWindow {
   constructor({ nodeId, title, rows, widthChars, container, manager }) {
+    super({ id: nodeId, title, widthChars, container, manager, kind: 'detail' });
     this.nodeId = nodeId;
-    this.title = title;
     this.rows = rows;
-    this.widthChars = widthChars;
-    this.container = container;
-    this.manager = manager;
-    this.isMinimized = false;
-    this.saved = null;          // {x, y} před minimalizací
-    this.dragOffset = null;
-
-    this.el = document.createElement('div');
-    this.el.dataset.role = 'detail-window';
-    this.el.dataset.nodeId = nodeId;
-    this.el.style.cssText = [
-      'position:absolute', 'left:0', 'top:0', 'box-sizing:border-box',
-      'background:var(--vb-window-body-bg, rgba(255,255,255,0.97))',
-      'color:var(--vb-window-body-fg, #1f2430)',
-      'box-shadow:var(--vb-window-shadow, 0 6px 20px rgba(0,0,0,0.22))',
-      'border-radius:6px', 'overflow:hidden', 'user-select:none',
-      'font:13px/1.5 system-ui,sans-serif', 'z-index:900',
-    ].join(';');
-
-    this._buildHeader();
     this._buildBody();
-    container.appendChild(this.el);
-
-    // počáteční pozice: lehce odsazená kaskáda podle počtu oken
-    const bounds = this._bounds();
-    const offset = (manager.windows.size % 8) * 24;
-    const start = clampToCanvas(40 + offset, 40 + offset,
-      this._width(), 200, bounds);
-    this._place(start.x, start.y);
-
-    this.el.addEventListener('pointerdown', () => this.bringToFront());
-  }
-
-  _width() {
-    // šířka těla v ch + padding/border; ch ~ 8px monospace
-    return this.widthChars * 8 + 24;
-  }
-
-  _bounds() {
-    return {
-      width: this.container.clientWidth || 800,
-      height: this.container.clientHeight || 600,
-    };
-  }
-
-  _buildHeader() {
-    const bar = document.createElement('div');
-    bar.dataset.role = 'detail-titlebar';
-    bar.style.cssText = [
-      'display:flex', 'align-items:center', 'gap:6px',
-      'padding:4px 6px', 'cursor:move',
-      'background:var(--vb-window-header-bg, #d8dde6)',
-      'color:var(--vb-window-header-fg, #1f2430)',
-    ].join(';');
-
-    this.closeGadget = this._gadget('close', '×');   // ×
-    this.closeGadget.addEventListener('click', (e) => {
-      e.stopPropagation();
-      this.close();
-    });
-
-    this.titleEl = document.createElement('div');
-    this.titleEl.textContent = this.title;
-    this.titleEl.style.cssText = [
-      'flex:1', 'text-align:center', 'font-weight:600',
-      'white-space:nowrap', 'overflow:hidden', 'text-overflow:ellipsis',
-    ].join(';');
-
-    this.minGadget = this._gadget('minimize', '–');   // –
-    this.minGadget.addEventListener('click', (e) => {
-      e.stopPropagation();
-      this.minimize();
-    });
-
-    this.restoreGadget = this._gadget('restore', '▢'); // ▢
-    this.restoreGadget.addEventListener('click', (e) => {
-      e.stopPropagation();
-      this.restore();
-    });
-    this.restoreGadget.style.display = 'none';
-
-    bar.append(this.closeGadget, this.titleEl,
-      this.minGadget, this.restoreGadget);
-    this._dragFromHeader(bar);
-    this.bar = bar;
-    this.el.appendChild(bar);
-  }
-
-  _gadget(name, glyph) {
-    const g = document.createElement('button');
-    g.dataset.gadget = name;
-    g.textContent = glyph;
-    g.style.cssText = [
-      'flex:0 0 auto', 'width:18px', 'height:18px', 'line-height:16px',
-      'padding:0', 'border:1px solid var(--vb-window-gadget, #8a93a3)',
-      'border-radius:3px', 'background:transparent', 'cursor:pointer',
-      'color:var(--vb-window-gadget, #5a6573)', 'font-size:13px',
-    ].join(';');
-    return g;
+    this._mount();
   }
 
   _buildBody() {
     const body = document.createElement('div');
     body.dataset.role = 'detail-body';
     body.style.cssText = [
-      'padding:6px 10px',
-      `width:${this.widthChars}ch`,
-      'max-width:90vw',
+      'padding:6px 10px', `width:${this.widthChars}ch`, 'max-width:90vw',
       'font:13px/1.6 ui-monospace,SFMono-Regular,Menlo,monospace',
       'overflow:auto',
     ].join(';');
     this.body = body;
-    this._renderRows();
+    this._renderBody();
     this.el.appendChild(body);
   }
 
-  _renderRows() {
+  _renderBody() {
     this.body.replaceChildren();
     const table = document.createElement('table');
     table.style.cssText = 'border-collapse:collapse;width:100%';
@@ -230,47 +114,6 @@ export class DetailWindow {
     }
   }
 
-  _dragFromHeader(bar) {
-    bar.addEventListener('pointerdown', (e) => {
-      if (e.target.dataset.gadget) return;   // klik na gadget netáhne
-      this.bringToFront();
-      const rect = this.el.getBoundingClientRect();
-      const cont = this.container.getBoundingClientRect();
-      this.dragOffset = {
-        x: e.clientX - rect.left, y: e.clientY - rect.top,
-        contLeft: cont.left, contTop: cont.top,
-      };
-      bar.setPointerCapture(e.pointerId);
-    });
-    bar.addEventListener('pointermove', (e) => {
-      if (!this.dragOffset || this.isMinimized) return;
-      const x = e.clientX - this.dragOffset.contLeft - this.dragOffset.x;
-      const y = e.clientY - this.dragOffset.contTop - this.dragOffset.y;
-      const pos = clampToCanvas(x, y, this._width(), this._headerH(),
-        this._bounds());
-      this._place(pos.x, pos.y);
-    });
-    const end = (e) => {
-      if (this.dragOffset) {
-        this.dragOffset = null;
-        try { bar.releasePointerCapture(e.pointerId); } catch { /* noop */ }
-      }
-    };
-    bar.addEventListener('pointerup', end);
-    bar.addEventListener('pointercancel', end);
-  }
-
-  _headerH() {
-    return this.bar.offsetHeight || DOCK_SLOT_HEIGHT;
-  }
-
-  _place(x, y) {
-    this.x = x;
-    this.y = y;
-    this.el.style.left = `${x}px`;
-    this.el.style.top = `${y}px`;
-  }
-
   update({ title, rows }) {
     if (title != null) {
       this.title = title;
@@ -278,76 +121,21 @@ export class DetailWindow {
     }
     if (rows != null) {
       this.rows = rows;
-      if (!this.isMinimized) this._renderRows();
+      if (!this.isMinimized) this._renderBody();
     }
-  }
-
-  minimize() {
-    if (this.isMinimized) return;
-    this.isMinimized = true;
-    this.saved = { x: this.x, y: this.y };
-    this.body.style.display = 'none';
-    this.minGadget.style.display = 'none';
-    this.restoreGadget.style.display = '';
-    this.el.dataset.role = 'detail-dock-strip';
-    this.el.style.background = 'var(--vb-window-dock-bg, #c2c9d4)';
-    this.el.style.width = `${DOCK_SLOT_WIDTH}px`;
-    this.titleEl.style.fontSize = '11px';
-    const slot = this.manager._assignDockSlot(this);
-    const bounds = this._bounds();
-    const pos = dockLayout(slot, DOCK_SLOT_WIDTH, DOCK_GAP,
-      bounds.height, DOCK_SLOT_HEIGHT);
-    this._place(pos.x, pos.y);
-  }
-
-  restore() {
-    if (!this.isMinimized) return;
-    this.isMinimized = false;
-    this.manager._releaseDockSlot(this);
-    this.el.dataset.role = 'detail-window';
-    this.el.style.background = 'var(--vb-window-body-bg, rgba(255,255,255,0.97))';
-    this.el.style.width = '';
-    this.titleEl.style.fontSize = '';
-    this.body.style.display = '';
-    this.minGadget.style.display = '';
-    this.restoreGadget.style.display = 'none';
-    this._renderRows();
-    const pos = this.saved ?? { x: 40, y: 40 };
-    this._place(pos.x, pos.y);
-    this.bringToFront();
-  }
-
-  bringToFront() {
-    this.setZ(this.manager._nextZ());
-  }
-
-  setZ(z) {
-    this.el.style.zIndex = String(z);
-  }
-
-  applyTheme() {
-    // chrome čte živé CSS proměnné z :root – stačí překreslit řádky kvůli
-    // inline pozadí value buněk, zbytek se přepočte sám.
-    if (!this.isMinimized) this._renderRows();
-  }
-
-  close() {
-    if (this.isMinimized) this.manager._releaseDockSlot(this);
-    this.el.remove();
-    this.manager._forget(this.nodeId);
   }
 }
 
-/** Spravuje kolekci DetailWindow nad app kontejnerem: otevírání podle uzlu,
- *  z-order, dok slots, živé patche, téma. Generický – nezná doménu. */
+/** Spravuje detailní i control okna nad app kontejnerem: otevírání, z-order,
+ *  dok, živé patche (jen detailní okna). */
 export class WindowManager {
   constructor(container, store, getTheme = () => null) {
     this.container = container;
     this.store = store;
     this.getTheme = getTheme;
-    this.windows = new Map();        // nodeId -> DetailWindow
+    this.windows = new Map();        // id -> BaseWindow (nodeId | window_id)
     this.z = 900;
-    this.dockSlots = [];             // index -> DetailWindow | null
+    this.dockSlots = [];
   }
 
   _config() {
@@ -363,7 +151,7 @@ export class WindowManager {
       return existing;
     }
     const node = this.store.nodes.get(nodeId);
-    if (!node) return null;          // neexistující uzel → no-op
+    if (!node) return null;
     const cfg = this._config();
     const win = new DetailWindow({
       nodeId,
@@ -378,10 +166,34 @@ export class WindowManager {
     return win;
   }
 
+  openControl(spec, onSubmit) {
+    const existing = this.windows.get(spec.window_id);
+    if (existing) existing.close();          // nahrazení stejného window_id
+    const win = new ControlWindow({
+      id: spec.window_id,
+      title: spec.title,
+      fields: spec.fields,
+      widthChars: CONTROL_WIDTH_CHARS,
+      onSubmit,
+      container: this.container,
+      manager: this,
+    });
+    this.windows.set(spec.window_id, win);
+    win.bringToFront();
+    return win;
+  }
+
+  closeControl(windowId) {
+    this.windows.get(windowId)?.close();
+  }
+
   onPatch(patch) {
-    if (this.windows.size === 0) return;
-    const { refresh, close } = windowsToRefresh(
-      patch, new Set(this.windows.keys()));
+    const detailIds = new Set();
+    for (const [id, win] of this.windows) {
+      if (win.kind === 'detail') detailIds.add(id);
+    }
+    if (detailIds.size === 0) return;
+    const { refresh, close } = windowsToRefresh(patch, detailIds);
     for (const id of close) this.windows.get(id)?.close();
     const cfg = this._config();
     for (const id of refresh) {
@@ -420,7 +232,7 @@ export class WindowManager {
     win._dockSlot = null;
   }
 
-  _forget(nodeId) {
-    this.windows.delete(nodeId);
+  _forget(id) {
+    this.windows.delete(id);
   }
 }

--- a/frontend/tests/control_window.test.js
+++ b/frontend/tests/control_window.test.js
@@ -28,6 +28,24 @@ describe('clampValue', () => {
     expect(clampValue(enumField, 'spline')).toBe('spline');
     expect(clampValue(enumField, 'ghost')).toBe('line');
   });
+
+  it('enum s ne-string hodnotou matchne nativní hodnotu', () => {
+    const f = {
+      key: 'm', type: 'enum', value: 0,
+      options: [{ value: 0, label: 'A' }, { value: 1, label: 'B' }],
+    };
+    expect(clampValue(f, 1)).toBe(1);       // nativní číslo projde
+    expect(clampValue(f, '1')).toBe(0);     // string nematchne → fallback value
+  });
+
+  it('string null/undefined → prázdný řetězec', () => {
+    expect(clampValue(strField, null)).toBe('');
+    expect(clampValue(strField, undefined)).toBe('');
+  });
+
+  it('neznámý typ pole → stávající value', () => {
+    expect(clampValue({ type: 'bool', value: true }, 'x')).toBe(true);
+  });
 });
 
 describe('readValues', () => {

--- a/frontend/tests/control_window.test.js
+++ b/frontend/tests/control_window.test.js
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { clampValue, readValues } from '../src/render/control_window.js';
+
+const intField = { key: 'n', type: 'int', value: 30, min: 0, max: 100, step: 1 };
+const strField = { key: 's', type: 'string', value: 'ab', maxlength: 4 };
+const enumField = {
+  key: 'e', type: 'enum', value: 'line',
+  options: [{ value: 'line', label: 'Čáry' }, { value: 'spline', label: 'Splajny' }],
+};
+
+describe('clampValue', () => {
+  it('int clamp do rozmezí a na celé číslo', () => {
+    expect(clampValue(intField, '250')).toBe(100);
+    expect(clampValue(intField, -5)).toBe(0);
+    expect(clampValue(intField, '42')).toBe(42);
+    expect(clampValue(intField, 7.8)).toBe(8);
+  });
+
+  it('int nečíselný → ponech stávající value', () => {
+    expect(clampValue(intField, 'x')).toBe(30);
+  });
+
+  it('string ořez na maxlength', () => {
+    expect(clampValue(strField, 'abcdefg')).toBe('abcd');
+  });
+
+  it('enum platná hodnota projde, neplatná → stávající value', () => {
+    expect(clampValue(enumField, 'spline')).toBe('spline');
+    expect(clampValue(enumField, 'ghost')).toBe('line');
+  });
+});
+
+describe('readValues', () => {
+  it('z rawMap udělá čisté hodnoty jen pro známé klíče', () => {
+    const fields = [intField, enumField];
+    const out = readValues(fields, { n: '250', e: 'spline', zzz: 1 });
+    expect(out).toEqual({ n: 100, e: 'spline' });
+  });
+});

--- a/frontend/tests/edges.test.js
+++ b/frontend/tests/edges.test.js
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { bezierEdgePoints, EDGE_SEGMENTS } from '../src/render/edges.js';
+
+const a = { x: 0, y: 0, z: 0 };
+const b = { x: 10, y: 0, z: 0 };
+
+describe('bezierEdgePoints', () => {
+  it('vrátí segments+1 bodů', () => {
+    expect(bezierEdgePoints(a, b, 0.5, 8).length).toBe(9);
+    expect(bezierEdgePoints(a, b, 0.5).length).toBe(EDGE_SEGMENTS + 1);
+  });
+
+  it('koncové body jsou a a b', () => {
+    const p = bezierEdgePoints(a, b, 0.5, 8);
+    expect(p[0]).toEqual({ x: 0, y: 0, z: 0 });
+    expect(p[8].x).toBeCloseTo(10);
+    expect(p[8].y).toBeCloseTo(0);
+    expect(p[8].z).toBeCloseTo(0);
+  });
+
+  it('elasticita 0 → kolineární (střed na úsečce)', () => {
+    const p = bezierEdgePoints(a, b, 0, 8);
+    expect(p[4].x).toBeCloseTo(5);
+    expect(p[4].y).toBeCloseTo(0);
+    expect(p[4].z).toBeCloseTo(0);
+  });
+
+  it('elasticita > 0 → prohnutí ve středu roste s elasticitou', () => {
+    const mid1 = bezierEdgePoints(a, b, 0.3, 8)[4];
+    const mid2 = bezierEdgePoints(a, b, 0.8, 8)[4];
+    const bow1 = Math.hypot(mid1.y, mid1.z);
+    const bow2 = Math.hypot(mid2.y, mid2.z);
+    expect(bow1).toBeGreaterThan(0);
+    expect(bow2).toBeGreaterThan(bow1);
+  });
+
+  it('hrana rovnoběžná s osou Y má platnou kolmici (prohnutí v X/Z)', () => {
+    const p = bezierEdgePoints({ x: 0, y: 0, z: 0 }, { x: 0, y: 10, z: 0 },
+      0.5, 8)[4];
+    expect(Math.hypot(p.x, p.z)).toBeGreaterThan(0);
+  });
+});

--- a/frontend/tests/edges.test.js
+++ b/frontend/tests/edges.test.js
@@ -39,4 +39,10 @@ describe('bezierEdgePoints', () => {
       0.5, 8)[4];
     expect(Math.hypot(p.x, p.z)).toBeGreaterThan(0);
   });
+
+  it('nulová hrana (a === b) nepadne, vrátí segments+1 koincidentních bodů', () => {
+    const p = bezierEdgePoints(a, a, 0.5, 4);
+    expect(p.length).toBe(5);
+    expect(p[2]).toEqual({ x: 0, y: 0, z: 0 });
+  });
 });

--- a/python/tests/test_canvas.py
+++ b/python/tests/test_canvas.py
@@ -20,7 +20,8 @@ def test_config_in_snapshot():
     assert cfg == {"title": "T", "dimensions": 2, "theme": "cyber",
                    "highlight_neighbors": 2, "quality": "auto",
                    "detail_window": {"rows": None, "width_chars": 42,
-                                     "open_on_click": True}}
+                                     "open_on_click": True},
+                   "edge_style": {"style": "line", "elasticity": 0.0}}
 
 
 def test_invalid_dimensions_raises():

--- a/python/tests/test_control_windows.py
+++ b/python/tests/test_control_windows.py
@@ -31,6 +31,21 @@ def test_open_window_replace_same_id():
     assert len(c.snapshot()["windows"]) == 1
 
 
+def test_replace_without_on_submit_clears_callback():
+    c = Canvas()
+    fired = threading.Event()
+    c.open_window(_win(), on_submit=lambda e: fired.set())
+    c.open_window(_win())          # nahrazení bez on_submit → callback zrušen
+    c.dispatch_event("window_submit",
+                     {"window_id": "render",
+                      "values": {"style": "spline"}, "client_id": "x"})
+    assert not fired.wait(0.3)     # callback se nesmí spustit
+    fields = {f["key"]: f["value"]
+              for f in c.snapshot()["windows"][0]["fields"]}
+    assert fields["style"] == "spline"   # apply běží nezávisle na callbacku
+    c.close()
+
+
 def test_close_window_removes_and_queues():
     c = Canvas()
     c.open_window(_win())

--- a/python/tests/test_control_windows.py
+++ b/python/tests/test_control_windows.py
@@ -1,0 +1,124 @@
+import threading
+
+import pytest
+from fastapi.testclient import TestClient
+
+from viewbase import Canvas, ControlWindow, create_app, protocol
+
+
+def _win():
+    w = ControlWindow("render", title="Vykreslování")
+    w.enum("style", "Hrany",
+           options=[("line", "Čáry"), ("spline", "Splajny")], value="line")
+    w.integer("elasticity", "Elasticita", min=0, max=100, value=30)
+    return w
+
+
+def test_open_window_queues_action_and_snapshot():
+    c = Canvas()
+    c.open_window(_win())
+    (a,) = c.drain_actions()
+    assert a["action"] == "open_window"
+    assert a["window_id"] == "render"
+    assert [f["key"] for f in a["fields"]] == ["style", "elasticity"]
+    assert [w["window_id"] for w in c.snapshot()["windows"]] == ["render"]
+
+
+def test_open_window_replace_same_id():
+    c = Canvas()
+    c.open_window(_win())
+    c.open_window(_win())
+    assert len(c.snapshot()["windows"]) == 1
+
+
+def test_close_window_removes_and_queues():
+    c = Canvas()
+    c.open_window(_win())
+    c.drain_actions()
+    c.close_window("render")
+    (a,) = c.drain_actions()
+    assert a == {"action": "close_window", "window_id": "render"}
+    assert c.snapshot()["windows"] == []
+
+
+def test_close_unknown_raises():
+    with pytest.raises(ValueError):
+        Canvas().close_window("ghost")
+
+
+def test_default_edge_style_is_line():
+    assert Canvas().config["edge_style"] == {"style": "line", "elasticity": 0.0}
+
+
+def test_set_edge_style_updates_config_and_action():
+    c = Canvas()
+    c.set_edge_style("spline", elasticity=0.6)
+    assert c.config["edge_style"] == {"style": "spline", "elasticity": 0.6}
+    (a,) = c.drain_actions()
+    assert a == {"action": "set_edge_style", "style": "spline",
+                 "elasticity": 0.6}
+
+
+def test_set_edge_style_clamps_elasticity():
+    c = Canvas()
+    c.set_edge_style("spline", elasticity=5.0)
+    assert c.config["edge_style"]["elasticity"] == 1.0
+
+
+def test_set_edge_style_invalid_raises():
+    with pytest.raises(ValueError):
+        Canvas().set_edge_style("zigzag")
+
+
+def test_window_submit_validates_and_calls_callback():
+    c = Canvas()
+    done = threading.Event()
+    got = {}
+
+    def cb(event):
+        got["values"] = event.values
+        got["window_id"] = event.window_id
+        done.set()
+
+    c.open_window(_win(), on_submit=cb)
+    c.dispatch_event("window_submit", {
+        "window_id": "render",
+        "values": {"style": "spline", "elasticity": 250, "ghost": 1},
+        "client_id": "x"})
+    assert done.wait(2.0)
+    assert got["values"] == {"style": "spline", "elasticity": 100}
+    assert got["window_id"] == "render"
+    fields = {f["key"]: f["value"]
+              for f in c.snapshot()["windows"][0]["fields"]}
+    assert fields["style"] == "spline"
+    assert fields["elasticity"] == 100
+    c.close()
+
+
+def test_window_submit_unknown_window_does_not_raise():
+    c = Canvas()
+    c.dispatch_event("window_submit",
+                     {"window_id": "ghost", "values": {}, "client_id": "x"})
+    c.close()
+
+
+def test_init_message_includes_windows_key():
+    msg = protocol.init_message(
+        seq=0, config={}, node_types={}, nodes=[], edges=[],
+        flow_types={}, flows=[], windows=[{"window_id": "w"}])
+    assert msg["windows"] == [{"window_id": "w"}]
+
+
+def test_init_carries_windows_and_edge_style():
+    c = Canvas()
+    c.open_window(_win())
+    c.set_edge_style("spline", 0.5)
+    with TestClient(create_app(c)) as client:
+        with client.websocket_connect("/ws") as ws:
+            ws.send_text(protocol.encode(
+                {"type": "hello", "protocol": protocol.PROTOCOL_VERSION}))
+            init = protocol.decode(ws.receive_text())
+    assert init["type"] == "init"
+    assert [w["window_id"] for w in init["windows"]] == ["render"]
+    assert init["config"]["edge_style"] == {"style": "spline",
+                                            "elasticity": 0.5}

--- a/python/tests/test_controls.py
+++ b/python/tests/test_controls.py
@@ -1,0 +1,78 @@
+import pytest
+
+from viewbase.controls import ControlWindow, validate_values
+
+
+def _fields():
+    w = ControlWindow("w", title="T")
+    w.integer("n", "N", min=0, max=100, value=30)
+    w.string("s", "S", maxlength=4, value="ab")
+    w.enum("e", "E", options=[("line", "Čáry"), ("spline", "Splajny")],
+           value="line")
+    return w.spec()["fields"]
+
+
+def test_spec_shape():
+    w = ControlWindow("render", title="Vykreslování")
+    w.integer("n", "N", min=0, max=10, value=5, step=2)
+    spec = w.spec()
+    assert spec["window_id"] == "render"
+    assert spec["title"] == "Vykreslování"
+    assert spec["fields"] == [
+        {"key": "n", "label": "N", "type": "int",
+         "value": 5, "min": 0, "max": 10, "step": 2}]
+
+
+def test_enum_normalizes_options_and_bare_values():
+    w = ControlWindow("w")
+    w.enum("e", "E", options=["a", ("b", "Bé")], value="a")
+    field = w.spec()["fields"][0]
+    assert field["options"] == [
+        {"value": "a", "label": "a"}, {"value": "b", "label": "Bé"}]
+
+
+def test_integer_min_gt_max_raises():
+    with pytest.raises(ValueError):
+        ControlWindow("w").integer("n", "N", min=5, max=1, value=2)
+
+
+def test_string_maxlength_nonpositive_raises():
+    with pytest.raises(ValueError):
+        ControlWindow("w").string("s", "S", maxlength=0)
+
+
+def test_enum_empty_options_raises():
+    with pytest.raises(ValueError):
+        ControlWindow("w").enum("e", "E", options=[], value=None)
+
+
+def test_validate_clamps_int():
+    f = _fields()
+    assert validate_values(f, {"n": 250}) == {"n": 100}
+    assert validate_values(f, {"n": -5}) == {"n": 0}
+    assert validate_values(f, {"n": 42}) == {"n": 42}
+
+
+def test_validate_int_non_numeric_dropped():
+    assert validate_values(_fields(), {"n": "x"}) == {}
+
+
+def test_validate_truncates_string():
+    assert validate_values(_fields(), {"s": "abcdefg"}) == {"s": "abcd"}
+
+
+def test_validate_enum_rejects_unknown():
+    f = _fields()
+    assert validate_values(f, {"e": "ghost"}) == {}
+    assert validate_values(f, {"e": "spline"}) == {"e": "spline"}
+
+
+def test_validate_drops_unknown_keys():
+    assert validate_values(_fields(), {"zzz": 1}) == {}
+
+
+def test_apply_updates_values():
+    w = ControlWindow("w")
+    w.integer("n", "N", min=0, max=10, value=1)
+    w.apply({"n": 7})
+    assert w.spec()["fields"][0]["value"] == 7

--- a/python/tests/test_controls.py
+++ b/python/tests/test_controls.py
@@ -46,11 +46,24 @@ def test_enum_empty_options_raises():
         ControlWindow("w").enum("e", "E", options=[], value=None)
 
 
+def test_enum_value_not_in_options_raises():
+    with pytest.raises(ValueError):
+        ControlWindow("w").enum("e", "E", options=["a", "b"], value="c")
+
+
 def test_validate_clamps_int():
     f = _fields()
     assert validate_values(f, {"n": 250}) == {"n": 100}
     assert validate_values(f, {"n": -5}) == {"n": 0}
     assert validate_values(f, {"n": 42}) == {"n": 42}
+
+
+def test_validate_int_coerces_float():
+    assert validate_values(_fields(), {"n": 3.9}) == {"n": 3}
+
+
+def test_validate_string_non_str_dropped():
+    assert validate_values(_fields(), {"s": 42}) == {}
 
 
 def test_validate_int_non_numeric_dropped():

--- a/python/tests/test_protocol.py
+++ b/python/tests/test_protocol.py
@@ -7,7 +7,7 @@ def test_init_roundtrip():
     msg = protocol.init_message(
         seq=3, config={"dimensions": 3}, node_types={},
         nodes=[{"id": "a"}], edges=[],
-        flow_types={}, flows=[],
+        flow_types={}, flows=[], windows=[],
     )
     decoded = protocol.decode(protocol.encode(msg))
     assert decoded == msg

--- a/python/viewbase/__init__.py
+++ b/python/viewbase/__init__.py
@@ -1,7 +1,8 @@
 """viewbase – živá 2D/3D force-graph vizualizace ovládaná z Pythonu."""
 from . import protocol
 from .canvas import Canvas
+from .controls import ControlWindow
 from .server import create_app, serve
 
-__all__ = ["Canvas", "create_app", "serve", "protocol"]
+__all__ = ["Canvas", "ControlWindow", "create_app", "serve", "protocol"]
 __version__ = "0.1.0"

--- a/python/viewbase/canvas.py
+++ b/python/viewbase/canvas.py
@@ -7,9 +7,10 @@ import threading
 import types
 import uuid
 from concurrent.futures import ThreadPoolExecutor
-from .controls import ControlWindow, validate_values
 from contextlib import contextmanager
 from typing import Any, Callable, Iterator
+
+from .controls import ControlWindow, validate_values
 
 logger = logging.getLogger("viewbase")
 
@@ -219,14 +220,16 @@ class Canvas:
 
     def open_window(self, window: ControlWindow, *, on_submit=None) -> str:
         """Otevři/nahraď parametrické okno: ulož do stavu (pro init replay) a
-        zařaď akci open_window. on_submit dostane event s validovanými values."""
+        zařaď akci open_window. on_submit dostane event s validovanými values.
+        Pozor: při nahrazení okna stejného window_id bez on_submit se předchozí
+        callback zruší – chceš-li ho zachovat, předej on_submit znovu."""
         with self._lock:
             self._windows[window.window_id] = window
             if on_submit is not None:
                 self._window_callbacks[window.window_id] = on_submit
             else:
                 self._window_callbacks.pop(window.window_id, None)
-            self._actions.append({"action": "open_window", **window.spec()})
+            self._actions.append({**window.spec(), "action": "open_window"})
         return window.window_id
 
     def close_window(self, window_id: str) -> None:

--- a/python/viewbase/canvas.py
+++ b/python/viewbase/canvas.py
@@ -7,6 +7,7 @@ import threading
 import types
 import uuid
 from concurrent.futures import ThreadPoolExecutor
+from .controls import ControlWindow, validate_values
 from contextlib import contextmanager
 from typing import Any, Callable, Iterator
 
@@ -54,6 +55,7 @@ class Canvas:
             "quality": quality,
             "detail_window": {
                 "rows": None, "width_chars": 42, "open_on_click": True},
+            "edge_style": {"style": "line", "elasticity": 0.0},
         }
         self._lock = threading.RLock()
         self._nodes: dict[str, dict[str, Any]] = {}
@@ -61,6 +63,8 @@ class Canvas:
         self._node_types: dict[str, dict[str, Any]] = {}
         self._flow_types: dict[str, dict[str, Any]] = {}
         self._flows: dict[str, dict[str, Any]] = {}   # flow_id -> trvalý tok (do init)
+        self._windows: dict[str, ControlWindow] = {}
+        self._window_callbacks: dict[str, Any] = {}
         self._seq = 0
         self._batch_depth = 0
         self._pending = self._empty_pending()
@@ -70,6 +74,7 @@ class Canvas:
         self._actions: list[dict[str, Any]] = []
         self._closed = False
         self._node_label_template: str | None = None
+        self._register("window_submit", self._on_window_submit)
 
     @staticmethod
     def _empty_pending() -> dict[str, dict]:
@@ -210,6 +215,59 @@ class Canvas:
             del self._flows[flow_id]
             self._actions.append({"action": "stop_flow", "flow_id": flow_id})
 
+    # ---- control okna -------------------------------------------------
+
+    def open_window(self, window: ControlWindow, *, on_submit=None) -> str:
+        """Otevři/nahraď parametrické okno: ulož do stavu (pro init replay) a
+        zařaď akci open_window. on_submit dostane event s validovanými values."""
+        with self._lock:
+            self._windows[window.window_id] = window
+            if on_submit is not None:
+                self._window_callbacks[window.window_id] = on_submit
+            else:
+                self._window_callbacks.pop(window.window_id, None)
+            self._actions.append({"action": "open_window", **window.spec()})
+        return window.window_id
+
+    def close_window(self, window_id: str) -> None:
+        """Zavři okno: odeber ze stavu a zařaď akci close_window."""
+        with self._lock:
+            if self._windows.pop(window_id, None) is None:
+                raise ValueError(f"Okno '{window_id}' neexistuje")
+            self._window_callbacks.pop(window_id, None)
+            self._actions.append(
+                {"action": "close_window", "window_id": window_id})
+
+    def set_edge_style(self, style: str, elasticity: float = 0.0) -> None:
+        """Nastav vykreslení hran: 'line' nebo 'spline', elasticity 0..1.
+        Uloží do config (pro init) a zařadí akci set_edge_style."""
+        if style not in ("line", "spline"):
+            raise ValueError("style musí být 'line' nebo 'spline'")
+        elasticity = max(0.0, min(1.0, float(elasticity)))
+        with self._lock:
+            self.config["edge_style"] = {"style": style,
+                                         "elasticity": elasticity}
+            self._actions.append({"action": "set_edge_style", "style": style,
+                                  "elasticity": elasticity})
+
+    def _on_window_submit(self, event) -> None:
+        """Interní handler eventu window_submit: validuj values proti specu
+        okna, ulož je (pro init replay) a zavolej callback okna."""
+        window_id = getattr(event, "window_id", None)
+        raw = getattr(event, "values", None)
+        if not isinstance(raw, dict):
+            return
+        with self._lock:
+            window = self._windows.get(window_id)
+            if window is None:
+                return
+            clean = validate_values(window.spec()["fields"], raw)
+            window.apply(clean)
+            callback = self._window_callbacks.get(window_id)
+        if callback is not None:
+            event.values = clean
+            callback(event)
+
     # ---- uzly ----------------------------------------------------------
 
     def add_node(self, node_id: str, *, type: str | None = None,
@@ -325,6 +383,7 @@ class Canvas:
                 "edges": [self._public_edge(e) for e in self._edges.values()],
                 "flow_types": {n: dict(s) for n, s in self._flow_types.items()},
                 "flows": [dict(f) for f in self._flows.values()],
+                "windows": [w.spec() for w in self._windows.values()],
             }
 
     # ---- delty ---------------------------------------------------------

--- a/python/viewbase/controls.py
+++ b/python/viewbase/controls.py
@@ -55,6 +55,8 @@ class ControlWindow:
         norm = _normalize_options(options)
         if not norm:
             raise ValueError("enum: options nesmí být prázdné")
+        if value not in {opt["value"] for opt in norm}:
+            raise ValueError("enum: value musí být jedna z options")
         self._fields.append({
             "key": key, "label": label, "type": "enum",
             "value": value, "options": norm,

--- a/python/viewbase/controls.py
+++ b/python/viewbase/controls.py
@@ -1,0 +1,112 @@
+"""Control okno: backendem definovaný parametrický dialog.
+
+ControlWindow drží typovaná pole (int/string/enum). Spec jde na frontend (akce
+open_window i init), frontend z něj postaví formulář a hodnoty pošle zpět
+eventem window_submit. validate_values je čistá – clampuje příchozí hodnoty
+podle field descriptorů (bezpečnost: klient může poslat cokoli)."""
+from __future__ import annotations
+
+from typing import Any
+
+
+def _normalize_options(options: list) -> list[dict]:
+    """Seznam (value, label) dvojic nebo holých hodnot → [{value, label}]."""
+    normalized = []
+    for opt in options:
+        if isinstance(opt, (list, tuple)) and len(opt) == 2:
+            value, label = opt
+        else:
+            value, label = opt, str(opt)
+        normalized.append({"value": value, "label": str(label)})
+    return normalized
+
+
+class ControlWindow:
+    """Parametrické okno: uspořádaný seznam typovaných polí."""
+
+    def __init__(self, window_id: str, *, title: str = "") -> None:
+        self.window_id = window_id
+        self.title = title
+        self._fields: list[dict[str, Any]] = []
+
+    def integer(self, key: str, label: str, *, min: int, max: int,
+                value: int, step: int = 1) -> "ControlWindow":
+        if min > max:
+            raise ValueError("integer: min nesmí být větší než max")
+        self._fields.append({
+            "key": key, "label": label, "type": "int",
+            "value": int(value), "min": int(min), "max": int(max),
+            "step": int(step),
+        })
+        return self
+
+    def string(self, key: str, label: str, *, maxlength: int,
+               value: str = "") -> "ControlWindow":
+        if maxlength <= 0:
+            raise ValueError("string: maxlength musí být kladné")
+        self._fields.append({
+            "key": key, "label": label, "type": "string",
+            "value": str(value), "maxlength": int(maxlength),
+        })
+        return self
+
+    def enum(self, key: str, label: str, *, options: list,
+             value: Any) -> "ControlWindow":
+        norm = _normalize_options(options)
+        if not norm:
+            raise ValueError("enum: options nesmí být prázdné")
+        self._fields.append({
+            "key": key, "label": label, "type": "enum",
+            "value": value, "options": norm,
+        })
+        return self
+
+    def spec(self) -> dict[str, Any]:
+        return {
+            "window_id": self.window_id,
+            "title": self.title,
+            "fields": [dict(f) for f in self._fields],
+        }
+
+    def apply(self, values: dict[str, Any]) -> None:
+        """Přepiš value u polí podle (už zvalidovaných) hodnot."""
+        for field in self._fields:
+            if field["key"] in values:
+                field["value"] = values[field["key"]]
+
+
+_DROP = object()   # sentinel: hodnotu zahodit (None je validní string/enum)
+
+
+def _clamp_field(field: dict, raw: Any) -> Any:
+    """Zvaliduj jednu hodnotu podle field descriptoru. Vrátí _DROP, když je
+    hodnota nepoužitelná (volající ji vynechá)."""
+    kind = field["type"]
+    if kind == "int":
+        try:
+            value = int(raw)
+        except (TypeError, ValueError):
+            return _DROP
+        return max(field["min"], min(field["max"], value))
+    if kind == "string":
+        if not isinstance(raw, str):
+            return _DROP
+        return raw[:field["maxlength"]]
+    if kind == "enum":
+        allowed = {opt["value"] for opt in field["options"]}
+        return raw if raw in allowed else _DROP
+    return _DROP
+
+
+def validate_values(fields: list[dict], raw: dict) -> dict:
+    """Čistá validace: vrať jen platné, oříznuté hodnoty podle field
+    descriptorů. Neznámé klíče a nevalidní hodnoty se zahodí."""
+    clean = {}
+    for field in fields:
+        key = field["key"]
+        if key not in raw:
+            continue
+        value = _clamp_field(field, raw[key])
+        if value is not _DROP:
+            clean[key] = value
+    return clean

--- a/python/viewbase/controls.py
+++ b/python/viewbase/controls.py
@@ -67,8 +67,16 @@ class ControlWindow:
         return {
             "window_id": self.window_id,
             "title": self.title,
-            "fields": [dict(f) for f in self._fields],
+            "fields": [self._copy_field(f) for f in self._fields],
         }
+
+    @staticmethod
+    def _copy_field(field: dict) -> dict:
+        """Nezávislá kopie pole (i vnořený seznam options u enum)."""
+        copied = dict(field)
+        if "options" in copied:
+            copied["options"] = [dict(o) for o in copied["options"]]
+        return copied
 
     def apply(self, values: dict[str, Any]) -> None:
         """Přepiš value u polí podle (už zvalidovaných) hodnot."""

--- a/python/viewbase/protocol.py
+++ b/python/viewbase/protocol.py
@@ -9,7 +9,8 @@ PROTOCOL_VERSION = 1
 
 def init_message(*, seq: int, config: dict, node_types: dict,
                  nodes: list, edges: list,
-                 flow_types: dict, flows: list) -> dict[str, Any]:
+                 flow_types: dict, flows: list,
+                 windows: list) -> dict[str, Any]:
     return {
         "type": "init",
         "protocol": PROTOCOL_VERSION,
@@ -20,6 +21,7 @@ def init_message(*, seq: int, config: dict, node_types: dict,
         "edges": edges,
         "flow_types": flow_types,
         "flows": flows,
+        "windows": windows,
     }
 
 


### PR DESCRIPTION
## Souhrn

Backendem řízené **parametrické control okno**: backend definuje okno s typovanými poli (int/string/enum), frontend z něj postaví formulář, uživatel hodnoty změní a tlačítkem **Použít** je POSTem pošle zpět; backend je zvaliduje a podle nich řídí graf akcí protokolu.

- **DRY jádro** — jeden field descriptor sdílený oběma směry i pro validaci na obou stranách (backend je autorita). Nový typ pole = ~3 lokalizované změny.
- **Backend:** nový `controls.py` (`ControlWindow` + čistá `validate_values`); `Canvas.open_window`/`close_window`/`set_edge_style` + interní handler eventu `window_submit`; `init` nese `windows` + `config.edge_style` (přežijí reconnect).
- **Frontend:** extrakce `BaseWindow` (DRY) ze `DetailWindow`, nový `control_window.js` (formulář + Použít), zobecněný `WindowManager`; renderer kreslí hrany jako rovné čáry nebo **kvadratické bezierové křivky** (`bezierEdgePoints`, elasticita = prohnutí).
- **Vlajkový konzument:** `examples/showcase.py` — okno přepíná hrany Čáry/Splajny a nastavuje elasticitu.

Vzniklo zavedeným procesem spec → plán → subagenti (TDD, dvoustupňový review na task + závěrečný holistický review).
Spec: `docs/superpowers/specs/2026-06-17-control-okna-design.md` · Plán: `docs/superpowers/plans/2026-06-17-control-okna.md`.

## Test Plan

- [x] Backend: `python -m pytest python/tests -q` → 105 passed
- [x] Frontend: `cd frontend && npx vitest run` → 95 passed
- [x] Build: `cd frontend && npm run build` → OK
- [x] Boot-check: `python examples/showcase.py` nastartuje bez tracebacku
- [x] Manuální (prohlížeč): okno „Vykreslování" se otevře; přepnutí Splajny + Použít prohne hrany; elasticita mění zakřivení; F5 → okno i styl přežijí

🤖 Generated with [Claude Code](https://claude.com/claude-code)
